### PR TITLE
[REFACTOR] Replaced custom modal tag with Native HTML Dialog tag

### DIFF
--- a/src/app/photos/[id]/page.tsx
+++ b/src/app/photos/[id]/page.tsx
@@ -5,8 +5,8 @@ export default function PhotoPage({ params: { id } }: { params: { id: string } }
   const photo: Photo = swagPhotos.find((p) => p.id === id)!
 
   return (
-    <div className="container mx-auto my-10">
-      <div className="w-1/2 mx-auto border border-gray-700">
+    <div className="container mx-auto my-10 w-full sm:w-5/6 md:w-4/6 lg:w-3/5 xl:w-3/6 2xl:w-2/5 px-4">
+      <div className="mx-auto  border border-gray-700">
         <Frame photo={photo} />
       </div>
     </div>

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -1,49 +1,38 @@
-'use client'
-import { useCallback, useRef, useEffect, MouseEventHandler } from 'react'
-import { useRouter } from 'next/navigation'
+"use client";
+import { useCallback, useRef, useEffect, MouseEventHandler } from "react";
+import { useRouter } from "next/navigation";
 
-export default function Modal({ children }: { children: React.ReactNode }) {
-  const overlay = useRef(null)
-  const wrapper = useRef(null)
-  const router = useRouter()
+const Modal = ({ children }: { children: React.ReactNode }) => {
+  const router = useRouter();
+  const dialogRef = useRef<HTMLDialogElement | null>(null);
+  const wrapper = useRef<HTMLDivElement | null>(null);
 
   const onDismiss = useCallback(() => {
-    router.back()
-  }, [router])
-
-  const onClick: MouseEventHandler = useCallback(
-    (e) => {
-      if (e.target === overlay.current || e.target === wrapper.current) {
-        if (onDismiss) onDismiss()
-      }
-    },
-    [onDismiss, overlay, wrapper]
-  )
-
-  const onKeyDown = useCallback(
-    (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onDismiss()
-    },
-    [onDismiss]
-  )
+    router.back();
+  }, [router]);
 
   useEffect(() => {
-    document.addEventListener('keydown', onKeyDown)
-    return () => document.removeEventListener('keydown', onKeyDown)
-  }, [onKeyDown])
+    // errors in mobile browsers if not checked
+    if(!dialogRef.current?.open) dialogRef.current?.showModal();
+  }, []);
 
+  const overlayClick: MouseEventHandler = useCallback(
+    (event) => {
+      const element = wrapper?.current;
+      if(!element || element.contains(event.target as Node)) return;
+      onDismiss()
+    },
+    [onDismiss, wrapper]
+  );
+  
   return (
-    <div
-      ref={overlay}
-      className="fixed z-10 left-0 right-0 top-0 bottom-0 mx-auto bg-black/60"
-      onClick={onClick}
+    <dialog onClick={overlayClick} ref={dialogRef} onClose={onDismiss}
+    className={`backdrop:bg-black backdrop:bg-opacity-50 backdrop:backdrop-blur-sm 
+    p-0 w-full sm:w-5/6 md:w-4/6 lg:w-3/6 xl:w-2/5 2xl:w-2/6`}
     >
-      <div
-        ref={wrapper}
-        className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full sm:w-10/12 md:w-8/12 lg:w-1/2 p-6"
-      >
-        {children}
-      </div>
-    </div>
-  )
-}
+      <div ref={wrapper} >{children}</div>
+    </dialog>
+  );
+};
+
+export default Modal;


### PR DESCRIPTION
# Replaced custom modal logic with native HTML Dialog Tag implementation

## What is Dialog Tag?
Dialog tag is a not so new Native HTML Tag meant to be used for modals and dialogs (tootltips)
[Read More about HTML Dialog Tag here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog)

## Benefits
- Lower templating to implement modals
- No need to write backdrop overlay logic, is default implementation when used `dialogRef.current.openModal()`
- No need to write escape key logic, automatically closes on escape
- Other features include sending a message back to parent when modal is closed and more

## Must know
- We still have to implement what shall happen when close event is triggered, in our case we `router.back()`
- We also have to implement overlay click function

## Compatibility
- Supports all devices of desktop and mobile
- All events and functions (openModal, close) are supported by all browsers of desktop and mobile (tested)

## Extra's
- Tailwind has special utility for styling overlay/backdrop [Read More](https://tailwindcss.com/docs/hover-focus-and-other-states#dialog-backdrops)
  - I have used this feature to show as an example
- Wrote proper types for all `useRefs`
- Implemented `overlayClick` exit function on dialog click event instead of document click event which is more expensive computationally
- Rewrote responsive rules of  `/photos/[id]/page.tsx`
- Reduced number of lines of Modal Component from 49 -> 38

_This is also an attempt to increase awareness of Native Dialog Tag, not many developers know about it_
