### PR TITLE
use Link component to navigate away

### DIFF
--- a/app/@modal/(.)photos/[id]/modal.tsx
+++ b/app/@modal/(.)photos/[id]/modal.tsx
@@ -3,6 +3,7 @@
 import { type ElementRef, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { createPortal } from 'react-dom';
+import Link from 'next/link';
 
 export function Modal({ children }: { children: React.ReactNode }) {
   const router = useRouter();
@@ -22,7 +23,7 @@ export function Modal({ children }: { children: React.ReactNode }) {
     <div className="modal-backdrop">
       <dialog ref={dialogRef} className="modal" onClose={onDismiss}>
         {children}
-        <button onClick={onDismiss} className="close-button" />
+        <Link href="/">Close modal</Link>
       </dialog>
     </div>,
     document.getElementById('modal-root')!

--- a/app/@modal/[...catchAll]/page.tsx
+++ b/app/@modal/[...catchAll]/page.tsx
@@ -1,0 +1,3 @@
+export default function CatchAll() {
+  return null
+}


### PR DESCRIPTION
This is a showcase of not working closing modal when using Link to close modal instead or `router.back()` 

still reproducible https://github.com/vercel/next.js/issues/49662