### PR TITLE
feat: params using `await` with next.js latest version

### DIFF
--- a/app/@modal/(.)photos/[id]/page.tsx
+++ b/app/@modal/(.)photos/[id]/page.tsx
@@ -1,9 +1,10 @@
-import { Modal } from './modal';
+import { Modal } from "./modal";
 
-export default function PhotoModal({
-  params: { id: photoId },
+export default async function PhotoModal({
+  params,
 }: {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }) {
+  const photoId = (await params).id;
   return <Modal>{photoId}</Modal>;
 }

--- a/app/photos/[id]/page.tsx
+++ b/app/photos/[id]/page.tsx
@@ -1,14 +1,15 @@
 export const dynamicParams = false;
 
 export function generateStaticParams() {
-  let slugs = ['1', '2', '3', '4', '5', '6'];
+  let slugs = ["1", "2", "3", "4", "5", "6"];
   return slugs.map((slug) => ({ id: slug }));
 }
 
-export default function PhotoPage({
-  params: { id },
+export default async function PhotoPage({
+  params,
 }: {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }) {
+  const id = (await params).id;
   return <div className="card">{id}</div>;
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@types/node": "20.14.10",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
-    "next": "15.0.0-canary.61",
+    "next": "latest",
     "react": "^19.0.0-rc.0",
     "react-dom": "^19.0.0-rc.0",
     "typescript": "^5.5.3"


### PR DESCRIPTION
Hi, Team.
`params` is now being used as asynchronous in the latest version of next.js. ([reference](https://nextjs.org/docs/app/building-your-application/upgrading/version-15#async-request-apis-breaking-change)) 

Accordingly, I'd like to modify the example to fetch params asynchronously as well. 
Thank you!